### PR TITLE
implement a 'add image named [name] from [dataURI] to Pen+ Library' block

### DIFF
--- a/extensions/PenP/v7.js
+++ b/extensions/PenP/v7.js
@@ -911,32 +911,6 @@
           });
         });
       },
-      createPenPlusTextureInfoFromRenderTexture: function (renderTexture, name) {
-        const texture = parentExtension.penPlusCostumeLibrary[name]
-          ? parentExtension.penPlusCostumeLibrary[name].texture
-          : gl.createTexture();
-        gl.bindTexture(gl.TEXTURE_2D, texture);
-        twgl.bindFramebufferInfo(gl, renderTexture);
-        // Fill the texture with a copy of the texture from the render texture.
-        gl.copyTexImage2D(
-          gl.TEXTURE_2D,
-          0,
-          gl.RGBA,
-          0,
-          0,
-          renderTexture.width,
-          renderTexture.height,
-          0
-        );
-        // Let's assume all images are not a power of 2
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-        parentExtension.penPlusCostumeLibrary[name] = {
-          texture: texture,
-          width: renderTexture.width,
-          height: renderTexture.height,
-        };
-      },
 
       getTextureData: (texture, width, height) => {
         //?Initilize the temp framebuffer and assign it
@@ -2795,21 +2769,6 @@
               },
             },
           },
-          {
-            opcode: "addImageFromRenderTexture",
-            blockType: Scratch.BlockType.COMMAND,
-            text: Scratch.translate("add image named [imageName] from render texture [renderTextureName] to pen+ library"),
-            arguments: {
-              imageName: {
-                type: Scratch.ArgumentType.STRING,
-                defaultValue: "Image",
-              },
-              renderTextureName:{
-                type: Scratch.ArgumentType.STRING,
-                menu: "renderTexturesOnly",
-              },
-            },
-          },
 
           {
             blockType: Scratch.BlockType.LABEL,
@@ -4079,9 +4038,6 @@
       );
     }
 
-    addImageFromRenderTexture({imageName, renderTextureName}) {
-      this.textureFunctions.createPenPlusTextureInfoFromRenderTexture(this.renderTextures[this.prefixes.renderTextures+renderTextureName], imageName)
-    }
 
     addIMGfromDURI({ dataURI, name }) {
       //Just a simple thing to allow for pen drawing

--- a/extensions/PenP/v7.js
+++ b/extensions/PenP/v7.js
@@ -911,6 +911,32 @@
           });
         });
       },
+      createPenPlusTextureInfoFromRenderTexture: function (renderTexture, name) {
+        const texture = parentExtension.penPlusCostumeLibrary[name]
+          ? parentExtension.penPlusCostumeLibrary[name].texture
+          : gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        twgl.bindFramebufferInfo(gl, renderTexture);
+        // Fill the texture with a copy of the texture from the render texture.
+        gl.copyTexImage2D(
+          gl.TEXTURE_2D,
+          0,
+          gl.RGBA,
+          0,
+          0,
+          renderTexture.width,
+          renderTexture.height,
+          0
+        );
+        // Let's assume all images are not a power of 2
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        parentExtension.penPlusCostumeLibrary[name] = {
+          texture: texture,
+          width: renderTexture.width,
+          height: renderTexture.height,
+        };
+      },
 
       getTextureData: (texture, width, height) => {
         //?Initilize the temp framebuffer and assign it
@@ -2769,6 +2795,21 @@
               },
             },
           },
+          {
+            opcode: "addImageFromRenderTexture",
+            blockType: Scratch.BlockType.COMMAND,
+            text: Scratch.translate("add image named [imageName] from render texture [renderTextureName] to pen+ library"),
+            arguments: {
+              imageName: {
+                type: Scratch.ArgumentType.STRING,
+                defaultValue: "Image",
+              },
+              renderTextureName:{
+                type: Scratch.ArgumentType.STRING,
+                menu: "renderTexturesOnly",
+              },
+            },
+          },
 
           {
             blockType: Scratch.BlockType.LABEL,
@@ -4036,6 +4077,10 @@
         color,
         this.prefixes.penPlusTextures + name
       );
+    }
+
+    addImageFromRenderTexture({imageName, renderTextureName}) {
+      this.textureFunctions.createPenPlusTextureInfoFromRenderTexture(this.renderTextures[this.prefixes.renderTextures+renderTextureName], imageName)
     }
 
     addIMGfromDURI({ dataURI, name }) {


### PR DESCRIPTION
my proposed indirect solution to [#2 ](https://github.com/Pen-Group/extensions/issues/2)
this the use of image manipulation blocks, like the color at coordinate block, which would have otherwise been very dificult to achive, as extracting any data from a render texture was very dificult, on render textures.