### PR TITLE
fix the transperency issue

### DIFF
--- a/extensions/PenP/experi.js
+++ b/extensions/PenP/experi.js
@@ -254,7 +254,6 @@
                       void main()
                       {
                         gl_FragColor = texture2D(u_drawTex, v_texCoord);
-                        gl_FragColor.rgb = clamp(gl_FragColor.rgb / (gl_FragColor.a + 1e-3), 0.0, 1.0);
                       }
                   `,
         },


### PR DESCRIPTION
the draw shader was converting to straight alpha when it was supposed to be premultiplied.